### PR TITLE
Add Upcoming Events Preview

### DIFF
--- a/src/components/HomeUpcomingEventsPreview/HomeUpcomingEventsPreview.tsx
+++ b/src/components/HomeUpcomingEventsPreview/HomeUpcomingEventsPreview.tsx
@@ -1,0 +1,65 @@
+import { graphql, useStaticQuery } from 'gatsby';
+import React from 'react';
+import images from '../UpcomingEvents/images';
+import { PreviewImage, UpcomingEventLink } from './components';
+
+type UpcomingEventsQueryResult = {
+    allAasUpcomingEvents: {
+        edges: {
+            node: {
+                id: number;
+                code: string;
+                name: string;
+                startDate: string;
+                endDate: string;
+            };
+        }[];
+    };
+};
+type Props = {
+    eventIndex: number;
+};
+
+export default function HomeUpcomingEventsPreview({ eventIndex }: Props) {
+    if (Number.isNaN(eventIndex)) {
+        eventIndex = 0;
+    }
+    const eventsResult =
+        useStaticQuery<UpcomingEventsQueryResult>(UPCOMING_EVENTS);
+    const events = eventsResult.allAasUpcomingEvents.edges.map(
+        (edge) => edge.node,
+    );
+
+    const event = events[eventIndex];
+
+    return (
+        <UpcomingEventLink
+            href={`/onze-bijleskampen/kampagenda/#${event.code}`}
+        >
+            <h3>{event.name}</h3>
+            <h5>
+                {event.startDate} t/m {event.endDate}
+            </h5>
+            <PreviewImage
+                src={images[eventIndex]}
+                alt={`Een sfeer van een kamp zoals ${event.name}`}
+            />
+        </UpcomingEventLink>
+    );
+}
+
+const UPCOMING_EVENTS = graphql`
+    query AllUpcomingEventsPreview {
+        allAasUpcomingEvents {
+            edges {
+                node {
+                    id: id__normalized
+                    code
+                    name: naam
+                    startDate: datum_start
+                    endDate: datum_eind
+                }
+            }
+        }
+    }
+`;

--- a/src/components/HomeUpcomingEventsPreview/HomeUpcomingEventsPreview.tsx
+++ b/src/components/HomeUpcomingEventsPreview/HomeUpcomingEventsPreview.tsx
@@ -42,7 +42,7 @@ export default function HomeUpcomingEventsPreview({ eventIndex }: Props) {
             </h5>
             <PreviewImage
                 src={images[eventIndex]}
-                alt={`Een sfeer van een kamp zoals ${event.name}`}
+                alt={`Sfeer van een kamp zoals ${event.name}`}
             />
         </UpcomingEventLink>
     );

--- a/src/components/HomeUpcomingEventsPreview/components.ts
+++ b/src/components/HomeUpcomingEventsPreview/components.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const UpcomingEventLink = styled.a`
+    color: inherit;
+
+    &:hover {
+        color: #29b3e3;
+    }
+`;
+
+export const PreviewImage = styled.img`
+    position: relative;
+    width: 100%;
+`;

--- a/src/components/HomeUpcomingEventsPreview/index.ts
+++ b/src/components/HomeUpcomingEventsPreview/index.ts
@@ -1,0 +1,3 @@
+import HomeUpcomingEventsPreview from './HomeUpcomingEventsPreview';
+
+export default HomeUpcomingEventsPreview;

--- a/src/components/UpcomingEvents/UpcomingEvent.tsx
+++ b/src/components/UpcomingEvents/UpcomingEvent.tsx
@@ -9,7 +9,7 @@ import {
 } from './components';
 import images from './images';
 
-export type UpcomingEvent = {
+export type UpcomingEventType = {
     id: number;
     code: string;
     name: string;
@@ -30,7 +30,7 @@ export type UpcomingEvent = {
 export default function UpcomingEvent({
     event,
 }: {
-    event: UpcomingEvent;
+    event: UpcomingEventType;
 }): React.ReactElement {
     const image = images[event.id % images.length];
 

--- a/src/components/UpcomingEvents/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents/UpcomingEvents.tsx
@@ -1,8 +1,6 @@
 import { graphql, useStaticQuery } from 'gatsby';
 import React from 'react';
-import UpcomingEvent, {
-    UpcomingEvent as UpcomingEventType,
-} from './UpcomingEvent';
+import UpcomingEvent, { UpcomingEventType } from './UpcomingEvent';
 
 const UPCOMING_EVENTS = graphql`
     query AllUpcomingEvents {

--- a/src/components/WysiwygContent/ContentReplacers/AddUpcomingEventTile.tsx
+++ b/src/components/WysiwygContent/ContentReplacers/AddUpcomingEventTile.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { DOMNode, Element } from 'html-react-parser';
+import { ReactElement } from 'react';
+import { Replacer } from './Replacer';
+import HomeUpcomingEventsPreview from '../../HomeUpcomingEventsPreview';
+
+export default class AddUpcomingEventTile implements Replacer {
+    public acceptsRoute(location: Location): boolean {
+        return location.pathname === '/';
+    }
+
+    public supportsNode(node: DOMNode): boolean {
+        return (
+            node instanceof Element &&
+            node.tagName === 'span' &&
+            node.attribs['data-replacer'] === 'upcoming-event-tile'
+        );
+    }
+
+    public getNode(node: DOMNode): ReactElement {
+        if (!(node instanceof Element)) {
+            return <></>;
+        }
+
+        const eventIndex = parseInt(node.attribs['data-replacer-event']);
+        return <HomeUpcomingEventsPreview eventIndex={eventIndex} />;
+    }
+}

--- a/src/components/WysiwygContent/ContentReplacers/index.ts
+++ b/src/components/WysiwygContent/ContentReplacers/index.ts
@@ -1,11 +1,13 @@
 import AddDonateForm from './AddDonateForm';
 import AddUpcomingEvents from './AddUpcomingEvents';
 import ContentReplacerAggregator from './ContentReplacerAggregator';
+import AddUpcomingEventTile from './AddUpcomingEventTile';
 import ReplaceContactForm from './ReplaceContactForm';
 
 const contentReplacers = new ContentReplacerAggregator();
 contentReplacers.add(new ReplaceContactForm());
 contentReplacers.add(new AddDonateForm());
 contentReplacers.add(new AddUpcomingEvents());
+contentReplacers.add(new AddUpcomingEventTile());
 
 export default contentReplacers;


### PR DESCRIPTION
Add a tile for upcoming events.

With this tile we can recreate the front-page in wordpress without the JSON content.

There is no real way to test this without trashing the website.... so suggestions are welcome