### PR TITLE
Remove zomerkampen.net from sidebar as it is outdated

### DIFF
--- a/src/components/Sidebar-Widgets/UpcomingEvents/UpcomingEvents.tsx
+++ b/src/components/Sidebar-Widgets/UpcomingEvents/UpcomingEvents.tsx
@@ -59,16 +59,6 @@ const UpcomingEvents: React.FunctionComponent = () => {
             <Link to="/onze-bijleskampen/kampagenda/">
                 Volledige kampagenda
             </Link>
-            <UpcomingEventsExternalLink>
-                Onze kampen zijn ook te vinden op{' '}
-                <a
-                    href="https://zomerkampen.net"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    Zomerkampen.net
-                </a>
-            </UpcomingEventsExternalLink>
         </>
     );
 };


### PR DESCRIPTION
## How to test

- Do not see zomerkampen.net in the sidebar on pages 