### PR TITLE
Line header image font baseline to menu items

### DIFF
--- a/src/components/Layout/Main/Header/components.ts
+++ b/src/components/Layout/Main/Header/components.ts
@@ -17,18 +17,24 @@ export const StyledImg = styled.img`
     ${fromSize.sm(css`
         width: 140px;
         margin-right: ${spacing.md};
+        position: relative;
+        top: 5px;
     `)}
 
     ${fromSize.md(
         css`
             margin-right: ${spacing.xl};
             width: 220px;
+            position: relative;
+            top: 7px;
         `,
     )}
 
     ${fromSize.lg(
         css`
             width: 270px;
+            position: relative;
+            top: 8px;
         `,
     )}
 `;

--- a/src/components/Navigation/components.tsx
+++ b/src/components/Navigation/components.tsx
@@ -46,6 +46,10 @@ export const NavigationDesktop = styled.ul`
             background-color: ${colors.green};
             padding: ${spacing.md} 0;
         }
+
+        & > a {
+            padding-bottom: 0;
+        }
     }
 
     ul {
@@ -55,7 +59,7 @@ export const NavigationDesktop = styled.ul`
     a {
         text-align: center;
         width: 100%;
-        padding: ${spacing.lg} 0 ${spacing.sm} 0;
+        padding: ${spacing.lg} 0 ${spacing.lg} 0;
         display: inline-block;
         text-decoration: none;
         color: ${colors.foreground};


### PR DESCRIPTION
## How to test

- For each breakpoint
- See the anderwijs header image align neatly with the nav items
- I used the bottom of the s from anderwij*s* as baseline